### PR TITLE
APM-83: Drop hard-coded enum in `DigitalWalletProvider`

### DIFF
--- a/api/wallet/spec/definitions/DigitalWalletProvider.yaml
+++ b/api/wallet/spec/definitions/DigitalWalletProvider.yaml
@@ -1,4 +1,3 @@
 description: Провайдер электронных денежных средств
 type: string
-enum:
-  - Webmoney
+example: Paypal


### PR DESCRIPTION
Since we allow dynamically defined providers nowadays.